### PR TITLE
Refactor: article api 조회 시 id 추가

### DIFF
--- a/src/main/java/henesys/henesysbackend/article/domain/dto/ArticleDto.java
+++ b/src/main/java/henesys/henesysbackend/article/domain/dto/ArticleDto.java
@@ -12,6 +12,7 @@ public class ArticleDto {
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     public static class ResponseArticleDto {
 
+        private Long id;
         private String title;
         private String thumbnailImg;
         private String author;

--- a/src/main/java/henesys/henesysbackend/article/service/ArticleService.java
+++ b/src/main/java/henesys/henesysbackend/article/service/ArticleService.java
@@ -43,6 +43,7 @@ public class ArticleService {
 
     private static ArticleDto.ResponseArticleDto createArticleDto(Article article) {
         return ArticleDto.ResponseArticleDto.builder()
+                .id(article.getId())
                 .title(article.getTitle())
                 .thumbnailImg(article.getTitleImg())
                 .author(article.getMember().getName())

--- a/src/test/java/henesys/henesysbackend/article/service/ArticleServiceTest.java
+++ b/src/test/java/henesys/henesysbackend/article/service/ArticleServiceTest.java
@@ -73,6 +73,7 @@ public class ArticleServiceTest {
 
         //then
         assertThat(findDtos.size()).isEqualTo(3);
+        assertThat(findDtos.get(0).getId()).isEqualTo(articleA.getId());
         assertThat(findDtos.get(0).getTitle()).isEqualTo(articleA.getTitle());
         assertThat(findDtos.get(0).getContent()).isEqualTo(articleA.getContent());
         assertThat(findDtos.get(0).getAuthor()).isEqualTo(articleA.getMember().getName());


### PR DESCRIPTION
단일 게시물 조회 시, 게시글의 id 값을 받아야하기에, 프론트쪽에 id값을 넘겨줘야한다고 생각하여,
모든 게시물 조회 api에 id값을 넘기게 수정